### PR TITLE
Fix Hugging Face Space Python build contract

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,4 +62,5 @@ repos:
     rev: 1.7.5
     hooks:
     -   id: bandit
+        additional_dependencies: [pbr]
         args: ["-x", "tests/*.py"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ colorFrom: green
 colorTo: blue
 sdk: streamlit
 sdk_version: 1.29.0
+python_version: 3.11
 app_file: app.py
 pinned: true
 license: mit

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ openai==1.11.1
 pydantic==2.6.1
 PyYAML==6.0.1
 sentence-transformers==2.3.1
-streamlit==1.31.0
 torch==2.2.0 -f https://download.pytorch.org/whl/cpu/torch_stable.html

--- a/tests/test_space_build_contract.py
+++ b/tests/test_space_build_contract.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _space_metadata() -> dict[str, str]:
+    readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
+    front_matter = re.match(r"\A---\r?\n(.*?)\r?\n---", readme, re.DOTALL)
+    if front_matter is None:
+        raise AssertionError("README.md must start with Space YAML front matter")
+
+    metadata: dict[str, str] = {}
+    for line in front_matter.group(1).splitlines():
+        key, separator, value = line.partition(":")
+        if separator:
+            metadata[key.strip()] = value.strip().strip('"')
+    return metadata
+
+
+class SpaceBuildContractTests(unittest.TestCase):
+    def test_space_uses_python_311_and_one_streamlit_version_authority(self) -> None:
+        metadata = _space_metadata()
+        requirement_names = [
+            line.split("==", maxsplit=1)[0].strip().lower()
+            for line in (REPOSITORY_ROOT / "requirements.txt").read_text(
+                encoding="utf-8"
+            ).splitlines()
+            if line and not line.startswith("#")
+        ]
+
+        self.assertEqual("3.11", metadata.get("python_version"))
+        self.assertEqual("1.29.0", metadata.get("sdk_version"))
+        self.assertNotIn("streamlit", requirement_names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Pins the Hugging Face Space runtime to Python 3.11, keeps sdk_version 1.29.0 as the sole Streamlit authority, adds a build-contract regression test, and repairs the Bandit hook environment. Validation: unittest contract test passed; full pre-commit passed; Python 3.11 container installed the requirements plus Streamlit 1.29.0.